### PR TITLE
fix: ref not found in nested component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 *.log
+.idea
 .DS_Store
 dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 node_modules
-*.log
-.idea
-.DS_Store
 dist

--- a/src/index.js
+++ b/src/index.js
@@ -45,9 +45,14 @@ const MugenScroll = {
         execute()
       }
 
-      this._scrollContainer = this.scrollContainer ?
-        this.$parent.$refs[this.scrollContainer] :
-        window
+      if (this.scrollContainer) {
+        let parent = this
+        while ((parent = parent.$parent) && !this._scrollContainer) {
+          this._scrollContainer = parent.$refs[this.scrollContainer]
+        }
+      }
+
+      this._scrollContainer = this._scrollContainer || window
 
       // add event listeners
       this.check = throttle(execute, 200)


### PR DESCRIPTION
It could not find `ref` while using in nested component

e.g.

pager-helper

```vue
<template>
  <div>
    <slot></slot>

    <mugen-scroll :scroll-container="scrollContainer">
      <div class="pager-state">
        ...
      </div>
    </mugen-scroll>
  </div>
</template>

<script>
export default {
  props: {
     scrollContainer: String,
  }
}
</script>
```

using in my page

```vue
  <div ref="scrollList">
    <pager-helper scroll-container="scrollList">
      <template>
        <div v-for="item in list">
          ...
        </div>
      </template>
    </pager-helper>
  </div>
```

scrollList was in `$parent.$parent.$refs` instead of `$parent.$refs`