### PR TITLE
fix: handler执行完后增加递归判断

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,9 @@ const MugenScroll = {
           threshold: this.threshold
         })
         if (this.shouldHandle && inView) {
-          this.handler()
+          this.handler().then(() => {
+            execute();
+          });
         }
       }
 


### PR DESCRIPTION
handler执行一次后，如果列表的长度没有到达页面底部，就不会出现滚动条，无法再触发handler，所以执行handler后，应该再次判断"this.shouldHandle && inView"，如果符合条件，应该再次执行handler，直到条件不成立。
这对handler有要求，需要是一个promise对象或者handler函数返回一个promise对象，如果返回结果，执行resolve，如果没有更多数据，执行reject