### PR TITLE
fix: handle exception occurred when the element doesn't exist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,11 @@ const MugenScroll = {
   methods: {
     checkInView() {
       const execute = () => {
+        // The element can be removed
+        if (!this.$refs.scroll) {
+          return
+        }
+
         const inView = inViewport(this.$refs.scroll, {
           threshold: this.threshold
         })


### PR DESCRIPTION
`execute` function is throttled and the element can be removed between event and execution.